### PR TITLE
Fix pre-command-arg handling

### DIFF
--- a/refrepo_git.py
+++ b/refrepo_git.py
@@ -257,6 +257,7 @@ def inject_reference_repo_arg(args, root_dir, repo):
 
     original_args = args
     args = drop_pre_command_git_args(args)
+    dropped_args = len(original_args) - len(args)
 
     insert_pos = -1
     if len(args) >= 1 and args[0] == "clone":
@@ -268,6 +269,7 @@ def inject_reference_repo_arg(args, root_dir, repo):
 
     args = original_args
     if insert_pos > 0:
+        insert_pos += dropped_args
         args.insert(insert_pos, "--reference")
         args.insert(insert_pos + 1, str(repo_path))
 

--- a/test_refrepo_git.py
+++ b/test_refrepo_git.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import unittest
+from pathlib import Path
+
+from refrepo_git import inject_reference_repo_arg
+
+# Test inject_reference_repo_arg
+class InjectReferenceRepoArg(unittest.TestCase):
+    def setUp(self):
+        # These are needed for inject_reference_repo_arg, so set them to
+        # something we can be sure exists.
+        self.root = Path("/usr")
+        self.refrepo = Path("bin")
+        self.refrepo_full = self.root / self.refrepo
+
+    def test_simple_clone(self):
+        args = ["clone"]
+        expected = ["clone", "--reference", f"{self.refrepo_full}"]
+        actual = inject_reference_repo_arg(args, self.root, self.refrepo)
+
+        self.assertEqual(expected, actual)
+
+    def test_simple_submodule(self):
+        args = [
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+        ]
+        expected = [
+            "submodule",
+            "update",
+            "--reference",
+            f"{self.refrepo_full}",
+            "--init",
+            "--recursive",
+        ]
+        actual = inject_reference_repo_arg(args, self.root, self.refrepo)
+
+        self.assertEqual(expected, actual)
+
+    # Test that we handle arguments between git and the subcommand correctly.
+    def test_pre_command_args(self):
+        args = [
+            "-C",
+            "/tmp/test-repo",
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+        ]
+        expected = [
+            "-C",
+            "/tmp/test-repo",
+            "submodule",
+            "update",
+            "--reference",
+            f"{self.refrepo_full}",
+            "--init",
+            "--recursive",
+        ]
+        actual = inject_reference_repo_arg(args, self.root, self.refrepo)
+
+        self.assertEqual(expected, actual)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The inject_reference_repo_arg function should insert `--reference` after
the main set of commands (if applicable) but it fails to do that
properly in the face of pre command arguments.

Keep track of the dropped pre command arguments to fix this issue.

Also add some tests for `refrepo_git.py`.