### PR TITLE
Add Windows support to refrepo_git

### DIFF
--- a/refrepo_git.py
+++ b/refrepo_git.py
@@ -189,12 +189,13 @@ def atomic_write(path, data):
             dir=str(path.parent), mode="w", encoding="utf-8", delete=False
         )
         tmp_file.write(data)
+        tmp_file.close()
         tmp_path = Path(tmp_file.name)
         try:
             os.chmod(
                 tmp_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP
             )
-            tmp_path.rename(path)
+            tmp_path.replace(path)
             return True
         except OSError:
             tmp_path.unlink()


### PR DESCRIPTION
Without these changes refrepo_git would fail on the .rename(path) call with the temp file being locked as it hadn't being explicitly closed.